### PR TITLE
update method for firebase.service

### DIFF
--- a/src/firebase.service.ts
+++ b/src/firebase.service.ts
@@ -209,6 +209,23 @@ export class FirebaseService<T> {
     set(data:T):Promise<boolean> {
         return this.setData(data);
     }
+    
+    /**
+     * Update the objects children in this Firebase location. Passing null to updateData() will remove the value at the specified location.
+     * returns an promise that resolves when the operation is succesfull.
+     * @param data The object containing only the keys that should be updated in this location.
+     * @returns {Promise<boolean>} Returns a promise that resolves `true` if the data was succesfully updated. Otherwise the promise rejects if there was an error.
+     */
+    updateData(data:T):Promise<boolean> {
+        return FirebaseUtils.wrapFirebaseAsyncCall(this.firebase, this.firebase.update, [data]).then(() => true);
+    }
+    
+    /**
+     * @alias updateData(data)
+     */
+    update(data:T):Promise<boolean> {
+        return this.updateData(data);
+    }
 
     /**
      * Adds the given data to this Firebase location.

--- a/test/unit/firebase.service.spec.ts
+++ b/test/unit/firebase.service.spec.ts
@@ -13,6 +13,7 @@ export function main() {
                 offSpy,
                 childSpy,
                 setSpy,
+                updateSpy,
                 service;
 
             beforeEach(function () {
@@ -20,11 +21,13 @@ export function main() {
                 offSpy = Sinon.spy();
                 childSpy = Sinon.spy();
                 setSpy = Sinon.spy();
+                updateSpy = Sinon.spy();
                 firebase = {
                     on: onSpy,
                     off: offSpy,
                     child: childSpy,
-                    set: setSpy
+                    set: setSpy,
+                    update: updateSpy
                 };
                 service = new FirebaseService(firebase);
             });
@@ -224,8 +227,49 @@ export function main() {
                         .catch(done);
                 });
             });
+            
+            describe('.update(data)', function() {
+                it('should return a Promise', function () {
+                    var observable = service.update({});
+
+                    expect(observable instanceof Promise).toBe(true);
+                });
+                it('should call .update() on internal Firebase API Instance', function () {
+                    var obj = {updateKey: 'Update Value!'};
+                    service.updateData(obj);
+
+                    expect(updateSpy.called).toBe(true);
+                    expect(updateSpy.firstCall.args[0]).toBe(obj);
+                });
+                it('should resolve true when .update() calls given callback', function (done) {
+                    firebase.update = (data, callback) => {
+                        callback(null);
+                    };
+                    service.updateData({})
+                        .then(function (good) {
+                            expect(good).toBe(true);
+                            done();
+                        }).catch(done);
+                });
+                it('should resolve with error when .update() calls given callback with value', function (done) {
+                    firebase.update = (data, callback) => {
+                        callback('error');
+                    };
+
+                    service.updateData({})
+                        .catch(function (error) {
+                            expect(error).toBe('error');
+                            done();
+                        })
+                        .then(function () {
+                            done('Catch was not called');
+                        })
+                        .catch(done);
+                });
+            }); 
 
             describe('.on(event)', function () {
+                
                 it('should call .on(event, callback) on firebase instance when subscribed to', function () {
                     service.on('event').subscribe(() => {
                     });


### PR DESCRIPTION
hi, here is a pull request for firebase update method, (straight forward, analogous to the save method)
the update method is needed in addition to save method as the user may want to change only some of his data. which is not possibile in save method witch replaces whole object completely.
