### PR TITLE
Update to support Firebase 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@angular/core": "^2.0.0",
-    "firebase": "~2.4.2",
+    "firebase": "~3.0.4",
     "rxjs": "5.0.0-beta.12"
   },
   "devDependencies": {

--- a/src/firebase-array.ts
+++ b/src/firebase-array.ts
@@ -340,7 +340,7 @@ export class FirebaseArray<T> {
     private _wrap(func: Function) {
         return (args: any[]) => {
             var child: FirebaseDataSnapshot = args[0];
-            func(child.val(), child.key(), ...args);
+            func(child.val(), child.key, ...args);
         }
     }
 

--- a/src/firebase-auth.service.ts
+++ b/src/firebase-auth.service.ts
@@ -2,37 +2,26 @@ import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Rx';
 import {FirebaseService} from "./firebase.service";
 import {FirebaseUtils} from './firebase-utils';
-declare var Firebase:FirebaseStatic;
+declare var firebase:FirebaseStatic;
 
 /**
  * Defines a Firebase Service that provides Auth & Auth features.
  */
 @Injectable()
 export class FirebaseAuthService<T> {
-    /**
-     * Gets the FirebaseService that this Auth service is using.
-     * @returns {FirebaseService}
-     */
-    get service():FirebaseService<T> {
-        return this._firebase;
-    }
 
-    /**
-     * Gets the internal Firebase JavaScript API Service.
-     * @returns {Firebase}
-     */
-    get firebase():Firebase {
-        return this.service.firebase;
-    }
+    private _auth: any;
 
-    private _firebase:FirebaseService<T>;
+    public get auth(): any {
+        return this._auth;
+    }
 
     /**
      * Initializes a new FirebaseAuthService using the given FirebaseService.
      * @param firebase
      */
-    constructor(firebase:FirebaseService<T>) {
-        this._firebase = firebase;
+    constructor() {
+        this._auth = firebase.auth();
     }
 
     /**
@@ -41,9 +30,7 @@ export class FirebaseAuthService<T> {
      * @param credentials
      */
     authWithPassword(credentials:{email:string, password: string}):Promise<any> {
-        return FirebaseUtils.wrapFirebaseAsyncCall(this.firebase, this.firebase.authWithPassword, [credentials])
-            .then(args => args[1]);
+        return this.auth.signInWithEmailAndPassword(credentials.email, credentials.password);
     }
-
 
 }

--- a/src/firebase.config.ts
+++ b/src/firebase.config.ts
@@ -1,22 +1,40 @@
 import {Injectable} from '@angular/core';
-declare var Firebase:FirebaseStatic;
+declare var firebase:FirebaseStatic;
 
 /**
  * Defines an object that represents configuration for a FirebaseService.
  */
 @Injectable()
 export class FirebaseConfig {
+
     /**
-     * The URL that the service should use to connect to firebase.
-     * Typically in the format `https://<YOUR-FIREBASE-APP>.firebaseio.com`
+     * The database URL that the app should use to connect to Firebase.
+     * Typically in the format `https://<YOUR-FIREBASE-APP>.firebaseio.com`.
+     * @alias url
+     * @returns {string}
      */
-    public url:string;
+    public databaseURL: string;
+
+    /**
+     * The API Key that your application should use to connect to your Firebase app.
+     */
+    public apiKey: string;
+
+    /**
+     * The domain that your application should connect to for authorization.
+     * Typically in the format `https://<YOUR-PROJECT-ID>.firebaseapp.com`
+     */
+    public authDomain: string;
 
     /**
      * Creates a new FirebaseConfig object using the given Firebase URL.
-     * @param url The URL that should be used to connect to Firebase.
+     * @param databaseURL The URL that should be used to connect to the Firebase realtime database.
+     * @param apiKey The API Key that should be used to connect to Firebase.
+     * @param authDomain The domain that should be used for Auth.
      */
-    constructor(url:string) {
-        this.url = url;
+    constructor(databaseURL:string, apiKey: string, authDomain: string) {
+        this.databaseURL = databaseURL;
+        this.apiKey = apiKey;
+        this.authDomain = authDomain;
     }
 }

--- a/src/firebase.service.ts
+++ b/src/firebase.service.ts
@@ -63,6 +63,9 @@ import {FirebaseArray} from "./firebase-array";
  */
 @Injectable()
 export class FirebaseService<T> {
+
+    private static _initialized: boolean = false;
+
     /**
      * Gets the internal Firebase Instance.
      * @returns {Firebase}
@@ -266,10 +269,17 @@ export class FirebaseService<T> {
      */
     constructor(@Inject(FirebaseConfig) config: any) {
         if (!config) throw new Error("You must provide either a firebase configuration object or a firebase instance");
-        if((<FirebaseConfig>config).url) {
-            this._firebase = new Firebase((<FirebaseConfig>config).url);
+        if((<FirebaseConfig>config).databaseURL && config.apiKey && config.databaseURL) {
+            this._initalize(config);
+            this._firebase = firebase.database().ref();
         } else {
             this._firebase = <Firebase>config;
+        }
+    }
+
+    private _initalize(config: FirebaseConfig) {
+        if(!FirebaseService._initialized) {
+            firebase.initializeApp(config);
         }
     }
 

--- a/test/integration/firebase.module.spec.ts
+++ b/test/integration/firebase.module.spec.ts
@@ -5,7 +5,9 @@ export function main() {
         describe(".forRoot()", function () {
             it("should return an object that provides the given config object", () => {
                 var config = {
-                    url: "TestUrl"
+                    apiKey: "TestKey",
+                    authDomain: "AuthDomain",
+                    databaseURL: "TestUrl"
                 };
                 var result = FirebaseModule.forRoot(config);
 

--- a/test/unit/firebase-array.spec.ts
+++ b/test/unit/firebase-array.spec.ts
@@ -12,7 +12,7 @@ function createSnapshot(key: string, val: any): any {
         val() {
             return val;
         },
-        key() {
+        get key() {
             return key;
         }
     };

--- a/typings/firebase/firebase.d.ts
+++ b/typings/firebase/firebase.d.ts
@@ -284,10 +284,11 @@ interface Firebase extends FirebaseQuery {
 	onDisconnect(): FirebaseOnDisconnect;
 }
 interface FirebaseStatic {
-	/**
-	 * Constructs a new Firebase reference from a full Firebase URL.
-	 */
-	new (firebaseURL: string): Firebase;
+
+	initializeApp(config: any);
+	database():any;
+	auth(): any;
+
 	/**
 	 * Manually disconnects the Firebase client from the server and disables automatic reconnection.
 	 */
@@ -305,7 +306,7 @@ interface FirebaseStatic {
 		TIMESTAMP: any;
 	};
 }
-declare var Firebase: FirebaseStatic;
+declare var firebase: FirebaseStatic;
 
 declare module 'firebase' {
 	export = Firebase;


### PR DESCRIPTION
This PR updates the services to support Firebase 3 and up.

Most notably, `FirebaseService`, `FirebaseArray`, and `FirebaseAuthService` are affected. The changes, however, are minor. The biggest change is to `FirebaseConfig`, which now requires the `apiKey` and `authDomain`, in addition to `databaseURL`.
